### PR TITLE
Update all Versions

### DIFF
--- a/.github/workflows/dmg.yml
+++ b/.github/workflows/dmg.yml
@@ -13,8 +13,7 @@ on:
           - Catalina v10.15.7
           - Mojave v10.14.6
           - High Sierra v10.13.6
-          - Ventura Beta v13.0
-          - Monterey Beta v12.5
+          - Ventura v13.2
 
 jobs:
   build-dmg:
@@ -60,21 +59,12 @@ jobs:
           sleep 5
           softwareupdate --fetch-full-installer --full-installer-version 10.13.6
 
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Download macOS Ventura Beta Latest
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Download macOS Ventura Latest
         run: |
           sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
           sleep 5
-          softwareupdate --fetch-full-installer --full-installer-version 13.0
-
-      - if: github.event.inputs.macos_version == 'Monterey Beta v12.5'
-        name: Download macOS Monterey Beta Latest
-        run: |
-          sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
-          sleep 5
-          softwareupdate --fetch-full-installer --full-installer-version 12.5
-
-      # Generate DMG
+          softwareupdate --fetch-full-installer --full-installer-version 13.2
 
       # Monterey
 
@@ -166,22 +156,22 @@ jobs:
           name: macOS High Sierra
           path: "~/Desktop/HighSierra.dmg"
 
-      # Ventura Beta
+      # Ventura
 
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Generate Ventura Beta DMG
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Generate Ventura DMG
         run: |
           sudo hdiutil create -o /tmp/Ventura -size 16384m -volname Ventura -layout SPUD -fs HFS+J
           sudo hdiutil attach /tmp/Ventura.dmg -noverify -mountpoint /Volumes/Ventura
           sleep 10
-          sudo /Applications/Install\ macOS\ Ventura\ Beta.app/Contents/Resources/createinstallmedia --volume /Volumes/Ventura --nointeraction
-          hdiutil eject -force /Volumes/Install\ macOS\ Ventura\ Beta
+          sudo /Applications/Install\ macOS\ Ventura.app/Contents/Resources/createinstallmedia --volume /Volumes/Ventura --nointeraction
+          hdiutil eject -force /Volumes/Install\ macOS\ Ventura
           sudo mv /tmp/Ventura.dmg ~/Desktop/Ventura.dmg
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Upload Ventura Beta DMG
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Upload Ventura DMG
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: macOS Ventura Beta
+          name: macOS Ventura
           path: "~/Desktop/Ventura.dmg"
 
   re-run-failed-jobs:

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -13,7 +13,7 @@ on:
           - Catalina v10.15.7
           - Mojave v10.14.6
           - High Sierra v10.13.6
-          - Ventura Beta v13.0
+          - Ventura v13.2
 
 jobs:
   build-iso:
@@ -59,12 +59,12 @@ jobs:
           sleep 5
           softwareupdate --fetch-full-installer --full-installer-version 10.13.6
 
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Download macOS Ventura Beta Latest
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Download macOS Ventura Latest
         run: |
           sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
           sleep 5
-          softwareupdate --fetch-full-installer --full-installer-version 13.0
+          softwareupdate --fetch-full-installer --full-installer-version 13.2
 
       # Monterey
 
@@ -167,24 +167,24 @@ jobs:
           name: macOS High Sierra
           path: "~/Desktop/HighSierra.iso"
 
-      # Ventura Beta
+      # Ventura
 
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Generate Ventura Beta ISO
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Generate Ventura ISO
         run: |
           sudo hdiutil create -o /tmp/Ventura -size 16384m -volname Ventura -layout SPUD -fs HFS+J
           sudo hdiutil attach /tmp/Ventura.dmg -noverify -mountpoint /Volumes/Ventura
           sleep 10
-          sudo /Applications/Install\ macOS\ Ventura\ beta.app/Contents/Resources/createinstallmedia --volume /Volumes/Ventura --nointeraction
-          hdiutil eject -force /Volumes/Install\ macOS\ Ventura\ Beta
+          sudo /Applications/Install\ macOS\ Ventura.app/Contents/Resources/createinstallmedia --volume /Volumes/Ventura --nointeraction
+          hdiutil eject -force /Volumes/Install\ macOS\ Ventura
           hdiutil convert /tmp/Ventura.dmg -format UDTO -o ~/Desktop/Ventura
           mv -v ~/Desktop/Ventura.cdr ~/Desktop/Ventura.iso
           sudo rm -fv /tmp/Ventura.dmg
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Upload Ventura Beta ISO
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Upload Ventura ISO
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: macOS Ventura Beta
+          name: macOS Ventura
           path: "~/Desktop/Ventura.iso"
 
   re-run-failed-jobs:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -13,8 +13,7 @@ on:
           - Catalina v10.15.7
           - Mojave v10.14.6
           - High Sierra v10.13.6
-          - Ventura Beta v13.0
-          - Monterey Beta v12.5
+          - Ventura v13.2
 
 jobs:
   build-zip:
@@ -60,19 +59,12 @@ jobs:
           sleep 5
           softwareupdate --fetch-full-installer --full-installer-version 10.13.6
 
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
-        name: Download macOS Ventura Beta Latest
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
+        name: Download macOS Ventura Latest
         run: |
           sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
           sleep 5
-          softwareupdate --fetch-full-installer --full-installer-version 13.0
-
-      - if: github.event.inputs.macos_version == 'Monterey Beta v12.5'
-        name: Download macOS MontereyBeta Latest
-        run: |
-          sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
-          sleep 5
-          softwareupdate --fetch-full-installer --full-installer-version 12.5
+          softwareupdate --fetch-full-installer --full-installer-version 13.2
 
       # Monterey
 
@@ -134,17 +126,17 @@ jobs:
           name: macOS High Sierra
           path: "/Applications/Install macOS High Sierra.zip"
 
-      # Ventura Beta
+      # Ventura
 
-      - if: github.event.inputs.macos_version == 'Ventura Beta v13.0'
+      - if: github.event.inputs.macos_version == 'Ventura v13.2'
         name: ZIP and Upload
         run: |
           cd /Applications
-          zip -r "Install macOS Ventura beta.zip" "Install macOS Ventura beta.app"
+          zip -r "Install macOS Ventura.zip" "Install macOS Ventura.app"
       - uses: actions/upload-artifact@v3.1.0
         with:
-          name: macOS Ventura Beta
-          path: "/Applications/Install macOS Ventura beta.zip"
+          name: macOS Ventura
+          path: "/Applications/Install macOS Ventura.zip"
 
   re-run-failed-jobs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that Ventura is out of beta this updates the workflows to the latest Ventura 13.2.

I have also removed the reference to Monterey Beta v12.5 in the DMG and ZIP workflows which didn't appear to do anything.