### PR TITLE
Update Sonoma to stable release

### DIFF
--- a/.github/workflows/dmg.yml
+++ b/.github/workflows/dmg.yml
@@ -14,7 +14,7 @@ on:
           - Catalina v10.15.7
           - Mojave v10.14.6
           - High Sierra v10.13.6
-          - Sonoma Beta v14.0
+          - Sonoma v14.0
 
 jobs:
   build-dmg:
@@ -67,8 +67,8 @@ jobs:
           sleep 5
           softwareupdate --fetch-full-installer --full-installer-version 10.13.6
 
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Download macOS Sonoma Beta Latest
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Download macOS Sonoma Latest
         run: |
           sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
           sleep 5
@@ -184,22 +184,22 @@ jobs:
           name: macOS High Sierra
           path: "~/Desktop/HighSierra.dmg"
 
-      # Sonoma Beta
+      # Sonoma
 
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Generate Sonoma Beta DMG
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Generate Sonoma DMG
         run: |
           sudo hdiutil create -o /tmp/Sonoma -size 16384m -volname Sonoma -layout SPUD -fs HFS+J
           sudo hdiutil attach /tmp/Sonoma.dmg -noverify -mountpoint /Volumes/Sonoma
           sleep 10
-          sudo /Applications/Install\ macOS\ Sonoma\ Beta.app/Contents/Resources/createinstallmedia --volume /Volumes/Sonoma --nointeraction
-          hdiutil eject -force /Volumes/Install\ macOS\ Sonoma\ Beta
+          sudo /Applications/Install\ macOS\ Sonoma.app/Contents/Resources/createinstallmedia --volume /Volumes/Sonoma --nointeraction
+          hdiutil eject -force /Volumes/Install\ macOS\ Sonoma
           sudo mv /tmp/Sonoma.dmg ~/Desktop/Sonoma.dmg
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Upload Sonoma Beta DMG
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Upload Sonoma DMG
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: macOS Sonoma Beta
+          name: macOS Sonoma
           path: "~/Desktop/Sonoma.dmg"
 
   re-run-failed-jobs:

--- a/.github/workflows/dmg.yml
+++ b/.github/workflows/dmg.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-dmg:
     runs-on: macos-latest
-    if: github.repository == 'Comp-Labs/Download-macOS'
+    #if: github.repository == 'Comp-Labs/Download-macOS' -- Disable: Fails on forked and template generated repos
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-iso:
     runs-on: macos-latest
-    if: github.repository == 'Comp-Labs/Download-macOS'
+    #if: github.repository == 'Comp-Labs/Download-macOS' -- Disable: Fails on forked and template generated repos
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -14,7 +14,7 @@ on:
           - Catalina v10.15.7
           - Mojave v10.14.6
           - High Sierra v10.13.6
-          - Sonoma Beta v14.0
+          - Sonoma v14.0
 
 jobs:
   build-iso:
@@ -67,8 +67,8 @@ jobs:
           sleep 5
           softwareupdate --fetch-full-installer --full-installer-version 10.13.6
 
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Download macOS Sonoma Beta Latest
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Download macOS Sonoma Latest
         run: |
           sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
           sleep 5
@@ -196,24 +196,24 @@ jobs:
           name: macOS High Sierra
           path: "~/Desktop/HighSierra.iso"
 
-      # Sonoma Beta
+      # Sonoma
 
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Generate Sonoma Beta ISO
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Generate Sonoma ISO
         run: |
           sudo hdiutil create -o /tmp/Sonoma -size 16384m -volname Sonoma -layout SPUD -fs HFS+J
           sudo hdiutil attach /tmp/Sonoma.dmg -noverify -mountpoint /Volumes/Sonoma
           sleep 10
-          sudo /Applications/Install\ macOS\ Sonoma\ beta.app/Contents/Resources/createinstallmedia --volume /Volumes/Sonoma --nointeraction
-          hdiutil eject -force /Volumes/Install\ macOS\ Sonoma\ Beta
+          sudo /Applications/Install\ macOS\ Sonoma.app/Contents/Resources/createinstallmedia --volume /Volumes/Sonoma --nointeraction
+          hdiutil eject -force /Volumes/Install\ macOS\ Sonoma
           hdiutil convert /tmp/Sonoma.dmg -format UDTO -o ~/Desktop/Sonoma
           mv -v ~/Desktop/Sonoma.cdr ~/Desktop/Sonoma.iso
           sudo rm -fv /tmp/Sonoma.dmg
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Upload Sonoma Beta ISO
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Upload Sonoma ISO
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: macOS Sonoma Beta
+          name: macOS Sonoma
           path: "~/Desktop/Sonoma.iso"
 
   re-run-failed-jobs:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -14,7 +14,7 @@ on:
           - Catalina v10.15.7
           - Mojave v10.14.6
           - High Sierra v10.13.6
-          - Sonoma Beta v14.0
+          - Sonoma v14.0
 
 jobs:
   build-zip:
@@ -67,8 +67,8 @@ jobs:
           sleep 5
           softwareupdate --fetch-full-installer --full-installer-version 10.13.6
 
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
-        name: Download macOS Sonoma Beta Latest
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
+        name: Download macOS Sonoma Latest
         run: |
           sudo "/System/Library/PrivateFrameworks/Seeding.framework/Versions/Current/Resources/seedutil" enroll DeveloperSeed
           sleep 5
@@ -153,17 +153,17 @@ jobs:
           name: macOS High Sierra
           path: "/Applications/Install macOS High Sierra.zip"
 
-      # Sonoma Beta
+      # Sonoma
 
-      - if: github.event.inputs.macos_version == 'Sonoma Beta v14.0'
+      - if: github.event.inputs.macos_version == 'Sonoma v14.0'
         name: ZIP and Upload
         run: |
           cd /Applications
-          zip -r "Install macOS Sonoma beta.zip" "Install macOS Sonoma beta.app"
+          zip -r "Install macOS Sonoma.zip" "Install macOS Sonoma.app"
       - uses: actions/upload-artifact@v3.1.0
         with:
-          name: macOS Sonoma Beta
-          path: "/Applications/Install macOS Sonoma beta.zip"
+          name: macOS Sonoma
+          path: "/Applications/Install macOS Sonoma.zip"
 
   re-run-failed-jobs:
     runs-on: ubuntu-latest

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-zip:
     runs-on: macos-latest
-    if: github.repository == 'Comp-Labs/Download-macOS'
+    #if: github.repository == 'Comp-Labs/Download-macOS' -- Disable: Fails on forked and template generated repos
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Workflow fails since Sonoma v14.0 is no longer in beta. 
I updated the version and naming of files for it to work.

I have also removed the git repository check since it breaks on forked and template generated repos.

EDIT: Forgot to mention that i have of course tested that it still runs :)

